### PR TITLE
Add group_add to template

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -25,6 +25,12 @@ services:
       - {{ cap }}
 {% endfor %}
 {% endif %}
+{% if container.group_add is defined %}
+    group_add: 
+{% for group in container.group_add %}
+      - {{ group }}
+{% endfor %}
+{% endif %}
 {% if container.devices is defined %}
     devices:
 {% for device in container.devices %}


### PR DESCRIPTION
The LSIO docker image for Jellyfin has an option for `group_add`.  Adding as an option to the template.