### PR TITLE
Basic support for docker networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ appdata_path: /opt/appdata
 container_config_path: /config
 container_data_path: /data
 
+# docker networks
+# (only basic network creation currently supported)
+docker_networks:
+  - mynetwork
+
 # container definitions
 containers:
   - service_name: letsencrypt
@@ -41,6 +46,8 @@ containers:
       - TZ=Europe/London
       - VALIDATION=http
     mem_limit: 256m
+    networks:
+      - mynetwork
   - service_name: nextcloud
     active: true
     image: nextcloud
@@ -65,6 +72,8 @@ containers:
       - "{{ appdata_path }}/unifi:{{ container_config_path }}"
     include_global_env_vars: true
     restart: "{{ unless_stopped }}"
+    networks:
+      - mynetwork
   - service_name: quassel
     active: true
     image: linuxserver/quassel

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -153,5 +153,18 @@ services:
 {% if container.restart is defined %}
     restart: {{ container.restart }}
 {% endif %}
+{% if container.networks is defined %}
+    networks:
+{% for network in container.networks %}
+      - {{ network }}
+{% endfor %}
+{% endif %}
 {% endif %}
 {% endfor %}
+
+{% if docker_networks is defined %}
+networks:
+{% for network in docker_networks %}
+  {{ network }}:
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Adds (very) basic support for docker networks to allow separation of services onto their own networks. Doesn't support any advanced options, but allows for simple creation and utilisation of networks.