### PR TITLE
Adding user option to template

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -23,13 +23,13 @@ services:
     privileged: {{ container.privileged }}
 {% endif %}
 {% if container.cap_add is defined %}
-    cap_add: 
+    cap_add:
 {% for cap in container.cap_add %}
       - {{ cap }}
 {% endfor %}
 {% endif %}
 {% if container.group_add is defined %}
-    group_add: 
+    group_add:
 {% for group in container.group_add %}
       - {{ group }}
 {% endfor %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -154,6 +154,9 @@ services:
       - {{ envfile }}
 {% endfor %}
 {% endif %}
+{% if container.user is defined %}
+    user: {{ container.user }}
+{% endif %}
 {% if container.restart is defined %}
     restart: {{ container.restart }}
 {% endif %}


### PR DESCRIPTION
Some containers do not support PUID and GUID, in that case it is handy to have an option to pass the user to the container from the compose file