### PR TITLE
fix(template): comment for multiline ansible_managed

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 ---
 version: "{{ compose_schema_version | default('2') }}"
 services:


### PR DESCRIPTION
Thank you for this role. It helped me and I hope with this PR I can give a little bit back.

Fixed comment in template for docker-compose.yml when value of ansible_managed is multiline. example ansible.cfg:
```
[defaults]
ansible_managed=This file is managed by Ansible.%n
  date: %Y-%m-%d %H:%M:%S
  template: {file}
  host: {host}
  user: {uid}
```
According to the [documentation](https://docs.ansible.com/archive/ansible/2.4/playbooks_filters.html#comment-filter) this fix works with ansible v2.4, for which [the role is rated for](https://github.com/ironicbadger/ansible-role-docker-compose-generator/blob/master/meta/main.yml#L8).

Without this fix multiline ansible_managed will break rendered docker-compose.yml.