### PR TITLE
Add expose section to docker compose template

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -58,6 +58,12 @@ services:
       - {{ port }}
 {% endfor %}
 {% endif %}
+{% if container.expose is defined %}
+    expose:
+{% for expose_port in container.expose %}
+      - {{ expose_port }}
+{% endfor %}
+{% endif %}
 {% if ( container.environment is defined ) or ( container.include_global_env_vars is defined and container.include_global_env_vars) %}
     environment:
 {% if container.include_global_env_vars | default(false) %}


### PR DESCRIPTION
Add the expose section of docker compose to allow exposing ports without binding them to the host.
https://docs.docker.com/compose/compose-file/compose-file-v2/#expose