### PR TITLE
Add initial support for fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,21 @@ containers:
     mem_limit: 128m
     ports:
       - "4242:4242"
+  - service_name: netbox
+    active: true
+	image: docker.io/netboxcommunity/netbox:v3.6-2.7.0
+	anchor: netbox
+	user: "unit:root"
+  - service_name: netbox-worker
+    active: true
+	fragment: netbox
+	command:
+	  - /opt/netbox/venv/bin/python
+	  - /opt/netbox/netbox/manage.py
+	  - rqworker
+  - service_name: netbox-housekeeping
+    active: true
+	fragment: netbox
+	command:
+	  - /opt/netbox/housekeeping.sh
 ```

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -4,8 +4,12 @@ version: "{{ compose_schema_version | default('2') }}"
 services:
 {% for container in containers %}
 {% if container.active %}
-  {{ container.service_name }}:
+  {{ container.service_name }}:{% if container.anchor is defined %} &{{ container.anchor }}{% endif %}
+{% if container.fragment is defined %}
+	<<: *{{ container.fragment }}
+{% else %}
     image: {{ container.image }}
+{% endif %}
     container_name: {{ container.container_name | default(container.service_name) }}
 {% if container.extra_hosts is defined %}
     extra_hosts:

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -4,8 +4,8 @@ version: "{{ compose_schema_version | default('2') }}"
 services:
 {% for container in containers %}
 {% if container.active %}
-  {{ container.service_name }}:{% if container.anchor is defined %} &{{ container.anchor }}
-{% endif %}
+  {{ container.service_name }}:{% if container.anchor is defined %} &{{ container.anchor }}{% endif %}
+
 {% if container.fragment is defined %}
     <<: *{{ container.fragment }}
 {% else %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -4,7 +4,8 @@ version: "{{ compose_schema_version | default('2') }}"
 services:
 {% for container in containers %}
 {% if container.active %}
-  {{ container.service_name }}:{% if container.anchor is defined %} &{{ container.anchor }}{% endif %}
+  {{ container.service_name }}:{% if container.anchor is defined %} &{{ container.anchor }}
+{% endif %}
 {% if container.fragment is defined %}
     <<: *{{ container.fragment }}
 {% else %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -6,7 +6,7 @@ services:
 {% if container.active %}
   {{ container.service_name }}:{% if container.anchor is defined %} &{{ container.anchor }}{% endif %}
 {% if container.fragment is defined %}
-	<<: *{{ container.fragment }}
+    <<: *{{ container.fragment }}
 {% else %}
     image: {{ container.image }}
 {% endif %}


### PR DESCRIPTION
Add initial support for anchors and [fragments](https://github.com/compose-spec/compose-spec/blob/master/spec.md#fragments)

Example usage added to README.md

Usage:
```
containers:
  - service_name: netbox
    active: true
    image: docker.io/netboxcommunity/netbox:
    anchor: netbox
...
  - service_name: netbox-worker
    fragment: netbox
```

Result:
```
services:
  netbox: &netbox
    image: docker.io/netboxcommunity/netbox:
    container_name: netbox
...
  netbox-worker:
    <<: *netbox
    container_name: netbox-worker
```