### PR TITLE
Add support for healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ containers:
     mem_limit: 512m
     volumes:
       - "{{ appdata_path }}/unifi:{{ container_config_path }}"
+    depends_on:
+      - service: mongodb
+        condition: service_started
     include_global_env_vars: true
     restart: "{{ unless_stopped }}"
   - service_name: quassel

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -161,9 +161,13 @@ services:
 {% endif %}
 {% if container.healthcheck is defined %}
     healthcheck:
-      test: {{ container.healthcheck.test }}
+      test: "{{ container.healthcheck.test }}"
+{% if container.healthcheck.interval is defined %}
       interval: {{ container.healthcheck.interval }}
+{% endif %}
+{% if container.healthcheck.timeout is defined %}
       timeout: {{ container.healthcheck.timeout }}
+{% endif %}
 {% if container.healthcheck.retries is defined %}
       retries: {{ container.healthcheck.retries }}
 {% endif %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -1,4 +1,7 @@
 {{ ansible_managed | comment }}
+##############################
+# If you're seeing this, you're using a symlinked version of this role.
+##############################
 ---
 version: "{{ compose_schema_version | default('2') }}"
 services:
@@ -74,7 +77,12 @@ services:
 {% if container.depends_on is defined %}
     depends_on:
 {% for dependent in container.depends_on %}
+{% if dependent.condition is defined %}
+      {{ dependent }}:
+        condition: {{ dependent.condition }}
+{% else %}
       - {{ dependent }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if container.hostname is defined %}
@@ -154,8 +162,15 @@ services:
       - {{ envfile }}
 {% endfor %}
 {% endif %}
-{% if container.user is defined %}
-    user: {{ container.user }}
+{% if container.healthcheck is defined %}
+    healthcheck:
+      test: {{ container.healthcheck.test }}
+      interval: {{ container.healthcheck.interval }}
+      timeout: {{ container.healthcheck.timeout }}
+{% if container.healthcheck.retries is defined %}
+      retries: {{ container.healthcheck.retries }}
+{% endif %}
+      start_period: {{ container.healthcheck.start_period }}
 {% endif %}
 {% if container.restart is defined %}
     restart: {{ container.restart }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -1,7 +1,4 @@
 {{ ansible_managed | comment }}
-##############################
-# If you're seeing this, you're using a symlinked version of this role.
-##############################
 ---
 version: "{{ compose_schema_version | default('2') }}"
 services:
@@ -78,7 +75,7 @@ services:
     depends_on:
 {% for dependent in container.depends_on %}
 {% if dependent is mapping %}
-      {{ dependent }}:
+      {{ dependent.service}}:
         condition: {{ dependent.condition }}
 {% else %}
       - {{ dependent }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -77,7 +77,7 @@ services:
 {% if container.depends_on is defined %}
     depends_on:
 {% for dependent in container.depends_on %}
-{% if dependent.condition is defined %}
+{% if dependent is mapping %}
       {{ dependent }}:
         condition: {{ dependent.condition }}
 {% else %}


### PR DESCRIPTION
Add support for [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck) and [dependent conditions](https://docs.docker.com/compose/compose-file/compose-file-v2/#depends_on)

This is a non-breaking change, and dependents can still be defined as they are currently -

```
containers:
  - service_name: unifi
     ...
    depends_on:
      - mongodb
      - anotherservice
...
```

Example usage has been added to README.

Usage:

```
containers:
  - service_name: netbox-worker
    active: true
    ...
    depends_on:
      - service: netbox
        condition: service_healthy
...
```

Result:

```
services:
  netbox-worker:
    ...
    depends_on:
      netbox:
        condition: service_healthy
```