### PR TITLE
Add healthcheck parsing

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -46,6 +46,12 @@ services:
       - {{ volume }}
 {% endfor %}
 {% endif %}
+{% if container.healthcheck is defined %}
+    healthcheck:
+{% for param, value in container.healthcheck.items() %}
+      {{ param }}: {{ value }}
+{% endfor%}
+{% endif%}
 {% if container.labels is defined %}
     labels:
 {% for label in container.labels %}


### PR DESCRIPTION
I was implementing healthchecks on a set of containers on my new media server, and realized that this role had no facility for parsing those.  I added my logic in the middle of the template, but if you'd rather I move it to the end, let me know.

Cheers!