### PR TITLE
Automatically Add Quotes (") Around Env Lines With Incompatible Chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ containers:
       - 443:443
     volumes:
       - "{{ appdata_path }}/letsencrypt/config:{{ container_config_path }}"
+    networks:
+      - proxy
     restart: always
     depends_on:
       - unifi
@@ -78,4 +80,8 @@ containers:
     mem_limit: 128m
     ports:
       - "4242:4242"
+
+compose_networks:
+  - name: proxy
+    external: true
 ```

--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ containers:
 compose_networks:
   - name: proxy
     external: true
+    network_name: proxy
 ```

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -22,6 +22,12 @@ services:
 {% if container.privileged is defined %}
     privileged: {{ container.privileged }}
 {% endif %}
+{% if container.tty is defined %}
+    tty: {{ container.tty }}
+{% endif %}
+{% if container.stdin_open is defined %}
+    stdin_open: {{ container.stdin_open }}
+{% endif %}
 {% if container.cap_add is defined %}
     cap_add: 
 {% for cap in container.cap_add %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -171,6 +171,6 @@ services:
 {% if volumes is defined %}
 volumes:
 {% for volume in volumes %}
-  - {{ volume }}
+  {{ volume }}:
 {% endfor %}
 {% endif %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -95,6 +95,9 @@ services:
 {% if container.mem_limit is defined %}
     mem_limit: {{ container.mem_limit }}
 {% endif %}
+{% if container.single_command is defined %}
+    command: {{ container.single_command }}
+{% endif %}
 {% if container.command is defined %}
     command:
 {% for command in container.command %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -78,9 +78,9 @@ services:
 {% endif %}
 {% endif %}
 {% if container.links is defined %}
-  links:
+    links:
 {% for link in container.links %}
-    - {{ link }}
+      - {{ link }}
 {% endfor %}
 {% endif %}
 {% if container.depends_on is defined %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -77,7 +77,7 @@ services:
 {% endfor %}
 {% endif %}
 {% endif %}
-{% if container.links is define d%}
+{% if container.links is defined %}
 	links:
 {% for link in container.links %}
 	  - {{ link }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -161,3 +161,10 @@ services:
 {% endif %}
 {% endif %}
 {% endfor %}
+
+{% if volumes %}
+volumes:
+{% for volume in volumes %}
+  - {{ volume }}
+{% endfor %}
+{% endif %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -226,6 +226,9 @@ networks:
 {% if network.external is defined %}
     external: {{ network.external }}
 {% endif %}
+{% if network.network_name is defined %}
+    name: {{ network.network_name }}
+{% endif %}
 {% endfor %}
 
 {% if volumes is defined %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -61,7 +61,7 @@ services:
 {% if container.ports is defined %}
     ports:
 {% for port in container.ports %}
-      - {{ port }}
+      - "{{ port }}"
 {% endfor %}
 {% endif %}
 {% if ( container.environment is defined ) or ( container.include_global_env_vars is defined and container.include_global_env_vars) %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -78,7 +78,11 @@ services:
 {% endif %}
 {% if container.environment is defined %}
 {% for env_var in container.environment %}
+{% if ":" in env_var %}
+      - "{{ env_var }}"
+{% else %}
       - {{ env_var }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -168,7 +168,7 @@ services:
 {% endif %}
 {% endfor %}
 
-{% if volumes %}
+{% if volumes is defined %}
 volumes:
 {% for volume in volumes %}
   - {{ volume }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -210,6 +210,21 @@ services:
 {% if container.stop_grace_period is defined %}
     stop_grace_period: {{ container.stop_grace_period }}
 {% endif %}
+{% if container.networks is defined %}
+    networks:
+{% for network in container.networks %}
+      - {{ network }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}
+
+{% if compose_networks is defined %}
+networks:
+{% for network in compose_networks %}
+  {{ network.name }}:
+{% if network.external is defined %}
+    external: {{ network.external }}
 {% endif %}
 {% endfor %}
 

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -234,3 +234,4 @@ volumes:
   {{ volume }}:
 {% endfor %}
 {% endif %}
+{% endif %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -78,9 +78,9 @@ services:
 {% endif %}
 {% endif %}
 {% if container.links is defined %}
-	links:
+  links:
 {% for link in container.links %}
-	  - {{ link }}
+    - {{ link }}
 {% endfor %}
 {% endif %}
 {% if container.depends_on is defined %}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -71,6 +71,12 @@ services:
 {% endfor %}
 {% endif %}
 {% endif %}
+{% if container.links is define d%}
+	links:
+{% for link in container.links %}
+	  - {{ link }}
+{% endfor %}
+{% endif %}
 {% if container.depends_on is defined %}
     depends_on:
 {% for dependent in container.depends_on %}


### PR DESCRIPTION
An env var with a value that contains a `:` character can sometimes be invalid and not start properly:

```
$ docker-compose up -d
validating /opt/docker/my_container/docker-compose.yml: services.foobar.environment.0 must be a string
```

**Broken:**
```
---
services:
  foobar:
    image: foo/bar:latest
    container_name: foobar
    environment:
      - BLA_BLA=Blabla :: Biz Baz
      - THIS_IS=a test
```

**Fixed:**
```
---
services:
  foobar:
    image: foo/bar:latest
    container_name: foobar
    environment:
      - "BLA_BLA=Blabla :: Biz Baz"
      - THIS_IS=a test
```