### PR TITLE
feat: add networks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,33 @@ containers:
     mem_limit: 128m
     ports:
       - "4242:4242"
+  - service_name: service-on-custom-network
+    active: true
+    image: ubuntu:24.04
+    container_name: example
+    include_global_env_vars: true
+    networks:
+      my-network:
+      my-network-2:
+  - service_name: service-on-custom-network-wit-hardcoded-ip
+    active: true
+    image: ubuntu:24.04
+    container_name: example-hardcoded
+    include_global_env_vars: true
+    networks:
+      my-network:
+        ipv4_address: 172.16.0.1
+
+# optionally include networks to be created (these can be referenced using the networks key in the container definition above)
+networks:
+  - network_name: my-network
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.0.0/24
+  - network_name: my-network-2
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.1.0/24
 ```

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -15,6 +15,38 @@ services:
 {% if container.network_mode is defined %}
     network_mode: {{ container.network_mode }}
 {% endif %}
+{% if container.networks is defined %}
+    networks:
+{% for network_name, network_value in container.networks.items() %}
+{% if network_value is not mapping %}
+      - {{ network_name }}
+{% else %}
+      {{ network_name }}:
+{% if network_value.aliases is defined %}
+        aliases:
+{% for alias in network_value.aliases %}
+          - {{ alias }}
+{% endfor %}
+{% endif %}
+{% if network_value.ipv4_address is defined %}
+        ipv4_address: {{ network_value.ipv4_address }}
+{% endif %}
+{% if network_value.ipv6_address is defined %}
+        ipv6_address: {{ network_value.ipv6_address }}
+{% endif %}
+{% if network_value.link_local_ips is defined %}
+        link_local_ips:
+{% for ip in network_value.link_local_ips %}
+          - {{ ip }}
+{% endfor %}
+{% endif %}
+{% if network_value.mac_address is defined %}
+        mac_address: {{ network_value.mac_address }}
+{% endif %}
+        priority: {{ network_value.priority | default(0) }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if container.build is defined %}
     build: {{ container.build }}
 {% endif %}
@@ -197,3 +229,34 @@ services:
 {% endif %}
 {% endif %}
 {% endfor %}
+{% if networks is defined %}
+networks:
+{% for network in networks %}
+    {{ network.network_name }}:
+      driver: {{ network.driver | default("bridge") }}
+{% if network.driver_opts is defined %}
+      driver_opts:
+{% for opt in network.driver_opts %}
+        {{ opt }}
+{% endfor %}
+{% endif %}
+{% if network.ipam is defined %}
+      ipam:
+        driver: {{ network.ipam.driver | default("default") }}
+{% if network.ipam.config is defined %}
+        config:
+{% for config in network.ipam.config %}
+{% for key, value in config.items() %}
+            - {{ key }}: {{ value }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% if network.ipam.options is defined %}
+        options:
+{% for key, value in network.ipam.options.items() %}
+          {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
I've been making use of this role for a little while, but today found the need to define and use a custom network for my container. I noticed this wasn't currently supported, so figured I'd raise a PR to add the support.

This adds in support for defining top-level networks and attaching containers to them.

I've updated the README with example usage.

More info on the configuration in the docker docs:

* [Top-Level Networks](https://docs.docker.com/compose/compose-file/06-networks/)
* [Networks key in container definition](https://docs.docker.com/compose/compose-file/05-services/#networks)