### PR TITLE
allow any .ya?ml file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
         query('filetree', playbook_dir + '/services/' +
           (docker_compose_hostname | default(inventory_hostname))) |
         selectattr('state', 'eq', 'file') |
-        selectattr('path', 'regex', 'compose.ya?ml$') |
+        selectattr('path', 'regex', '.ya?ml$') |
         list
       }}
 


### PR DESCRIPTION
Currently the yaml files must be arranged like this:
```
.
└── services
    ├── ansible-hostname1
    │   ├── librespeed
    │   │   └── compose.yaml
    │   ├── jellyfin
    │   │   └── compose.yaml
    └── ansible-hostname2
        └── uptime-kuma
            └── compose.yaml
```

This change allows the following to work as well:

```
.
└── services
    ├── ansible-hostname1
    │   ├── librespeed.yaml
    │   ├── jellyfin.yaml
    └── ansible-hostname2
        └── uptime-kuma.yaml
```