### PR TITLE
main.yaml: introduce services_directory var to make it possible to overwrite location

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ By default, the role is looking for a directory structure under `services/` whic
 docker_compose_hostname: my-custom-hostname
 ```
 
+## Override services directory location
+
+By default, the role is looking for services by determining where the `playbook_dir` is and appending `services/`. 
+If your playbooks are for example inside a dedicated playbooks directory you can overwrite the services location by setting `services_directory` either in a task var, group_vars or host_vars.
+
 ## v1 of this role vs v2
 
 v1 of this role used a large custom data structure and an ever more complex jinja2 based templating approach. The custom nature of this approach added friction when adding new services and made it difficult to copy/paste from upstream repositories to try things out quickly.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
+---
 docker_compose_generator_output_path: "~"
 docker_compose_generator_uid: "1000"
 docker_compose_generator_gid: "1000"
+services_directory: "{{ playbook_dir }}/services/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   set_fact:
     compose_files: >-
       {{
-        query('filetree', playbook_dir + '/services/' +
+        query('filetree', services_directory +
           (docker_compose_hostname | default(inventory_hostname))) |
         selectattr('state', 'eq', 'file') |
         selectattr('path', 'regex', '.ya?ml$') |


### PR DESCRIPTION
fixes: ironicbadger/ansible-role-docker-compose-generator#42