### PR TITLE
solves the issue where top-level sections like networks were not indented correctly

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,8 +26,9 @@
       {% set service_name = file.src | dirname | basename %}
       {% if service_name not in (disabled_compose_files | default([])) %}
       {{ lookup('template', file.src)
-         | regex_replace('^(---|services:)\s*\n*', '')
-         | regex_replace('^', '  ') }}
+         | regex_replace('^(---)\s*\n*', '')
+         | regex_replace('^(services:)\s*\n*', '')
+         | regex_replace('(?m)^', '  ') }}
       {% endif %}
       {% endfor %}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,8 +26,7 @@
       {% set service_name = file.src | dirname | basename %}
       {% if service_name not in (disabled_compose_files | default([])) %}
       {{ lookup('template', file.src)
-         | regex_replace('^(---)\s*\n*', '')
-         | regex_replace('^(services:)\s*\n*', '')
+         | regex_replace('^(---|services:)\s*\n*', '')
          | regex_replace('(?m)^', '  ') }}
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
This solves the issue where top-level sections like networks: in additional compose files weren't correctly indented in the final output. With this change, each line from the included compose files will be properly indented with two spaces, maintaining the correct YAML structure in the generated compose file.