### PR TITLE
Allow .j2 ending on .yml/.yaml files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
         query('filetree', services_directory +
           (docker_compose_hostname | default(inventory_hostname))) |
         selectattr('state', 'eq', 'file') |
-        selectattr('path', 'regex', '.ya?ml$') |
+        selectattr('path', 'regex', '\.ya?ml(\.j2)?$') |
         list
       }}
 


### PR DESCRIPTION
This PR updates the template file selection regex to support optional .j2 extensions, enabling Jinja syntax highlighting and preventing editor errors when using Jinja variables in `compose.yml` files.

Old: `selectattr('path', 'regex', '.ya?ml$') |`
New: `selectattr('path', 'regex', '\.ya?ml(\.j2)?$') |`

This change allows files like `compose.yaml.j2` and `compose.yml.j2` to be recognized alongside standard YAML files.

I've tested this change in my own setup and confirmed it does not break existing configurations.

Not sure if this was a problem for anyone else but maybe worth considering merging.