### PR TITLE
Add config file deployment support with optional ZFS dataset creation

### DIFF
--- a/tasks/deploy-config.yml
+++ b/tasks/deploy-config.yml
@@ -1,0 +1,42 @@
+---
+- name: Read .dest file for {{ config_dir.path | basename }}
+  set_fact:
+    config_dest: "{{ lookup('template', config_dir.path + '/.dest') | trim }}"
+
+- name: Get parent ZFS dataset for {{ config_dir.path | basename }}
+  shell: "df --output=source {{ config_dest | dirname }} | tail -1"
+  register: parent_dataset
+  when: docker_compose_generator_zfs_enabled | default(false)
+  changed_when: false
+
+- name: Create ZFS dataset for {{ config_dir.path | basename }}
+  community.general.zfs:
+    name: "{{ parent_dataset.stdout }}/{{ config_dest | basename }}"
+    state: present
+  when:
+    - docker_compose_generator_zfs_enabled | default(false)
+    - parent_dataset.stdout is defined
+  become: true
+
+- name: Ensure destination directory exists
+  file:
+    path: "{{ config_dest }}"
+    state: directory
+    owner: "{{ docker_compose_generator_uid }}"
+    group: "{{ docker_compose_generator_gid }}"
+
+- name: Find config files to copy (excluding .dest)
+  find:
+    paths: "{{ config_dir.path }}"
+    excludes: ".dest"
+    file_type: file
+  delegate_to: localhost
+  register: config_files
+
+- name: Copy config files to destination
+  copy:
+    src: "{{ item.path }}"
+    dest: "{{ config_dest }}/{{ item.path | basename }}"
+    owner: "{{ docker_compose_generator_uid }}"
+    group: "{{ docker_compose_generator_gid }}"
+  loop: "{{ config_files.files }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
           (docker_compose_hostname | default(inventory_hostname))) |
         selectattr('state', 'eq', 'file') |
         selectattr('path', 'regex', '.ya?ml$') |
+        rejectattr('path', 'regex', 'config-[^/]+/') |
         list
       }}
 
@@ -37,3 +38,19 @@
     dest: "{{ docker_compose_generator_output_path }}/compose.yaml"
     owner: "{{ docker_compose_generator_uid }}"
     group: "{{ docker_compose_generator_gid }}"
+
+- name: Find all config directories
+  find:
+    paths: "{{ services_directory }}{{ docker_compose_hostname | default(inventory_hostname) }}"
+    patterns: "config-*"
+    file_type: directory
+    recurse: yes
+  delegate_to: localhost
+  register: config_dirs
+
+- name: Deploy config files from config-* directories
+  include_tasks: deploy-config.yml
+  loop: "{{ config_dirs.files }}"
+  loop_control:
+    loop_var: config_dir
+  when: config_dirs.files | length > 0


### PR DESCRIPTION
Extends the role to discover and deploy config files from config-* directories. Each config directory must contain a .dest file specifying the destination path (supports Ansible variable templating). Optionally creates ZFS datasets when docker_compose_generator_zfs_enabled is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)